### PR TITLE
Fix: Resolved HomeView NavigationLink error

### DIFF
--- a/Lab3WalkingTamagotchi/HomeView.swift
+++ b/Lab3WalkingTamagotchi/HomeView.swift
@@ -13,7 +13,6 @@ struct HomeView: View {
     @State var medicinePrice: Int = 100
     
     var body: some View {
-        VStack {
             NavigationView {
                 VStack {
                     HStack {
@@ -54,7 +53,9 @@ struct HomeView: View {
                     
                     ZStack {
                         Image("room")
+                            .resizable()
                             .frame(width: 350, height: 500)
+                            .aspectRatio(contentMode: .fit)
                             .clipShape(RoundedRectangle(cornerRadius: 8))
                         
                         VStack {
@@ -130,7 +131,6 @@ struct HomeView: View {
                     Spacer()
                 } //VStack
             } //NavigationView
-        } //VStack
         .padding()
     }
 }


### PR DESCRIPTION
NavigationLink를 클릭되지 않는 이슈를 해결했다.
화면 중앙의 이미지를 resizable하게 설정하지 않아 이미지가 상단을 침범하고 있었다.